### PR TITLE
修复微信h5弱网权限弹窗问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ package-lock.json
 yarn.lock
 *.log
 .vscode/
+.idea/
+/.idea/

--- a/src/infra/stores/common/device-setting/index.ts
+++ b/src/infra/stores/common/device-setting/index.ts
@@ -8,6 +8,7 @@ import {
   EduClassroomConfig,
   EduRoleTypeEnum,
   EduRoomTypeEnum,
+  Platform,
 } from 'agora-edu-core';
 import { LayoutMaskCode } from '../type';
 import { matchVirtualSoundCardPattern } from '../pretest/helper';
@@ -37,7 +38,7 @@ export class DeviceSettingUIStore extends EduUIStoreBase {
             const track = mediaControl.createCameraVideoTrack();
             track.setDeviceId(cameraDeviceId);
           }
-          if (this.classroomStore.connectionStore.classroomState === ClassroomState.Idle) {
+          if (this.classroomStore.connectionStore.classroomState === ClassroomState.Idle && EduClassroomConfig.shared.platform !== Platform.H5) {
             // if idle, e.g. pretest
             if (cameraDeviceId && cameraDeviceId !== DEVICE_DISABLE) {
               this._enableLocalVideo(true);
@@ -76,7 +77,7 @@ export class DeviceSettingUIStore extends EduUIStoreBase {
             const track = mediaControl.createMicrophoneAudioTrack();
             track.setRecordingDevice(recordingDeviceId);
           }
-          if (this.classroomStore.connectionStore.classroomState === ClassroomState.Idle) {
+          if (this.classroomStore.connectionStore.classroomState === ClassroomState.Idle && EduClassroomConfig.shared.platform !== Platform.H5) {
             // if idle, e.g. pretest
             if (recordingDeviceId && recordingDeviceId !== DEVICE_DISABLE) {
               this._enableLocalAudio(true);


### PR DESCRIPTION
微信环境H5中弹出摄像头申请权限弹框默认就是关的，网络异常重连之后又去获取，需要加上判断